### PR TITLE
fix: preserve audio tracks in the output stream and streamline URL check

### DIFF
--- a/apps/extension/entrypoints/injector.content.ts
+++ b/apps/extension/entrypoints/injector.content.ts
@@ -154,10 +154,7 @@ export default defineContentScript({
           }
           return raw
         }
-        if (
-          typeof raw === "string" &&
-          raw.startsWith("chrome-extension://")
-        )
+        if (typeof raw === "string" && raw.startsWith("chrome-extension://"))
           return policy!.createScriptURL(raw)
         return raw
       }
@@ -450,6 +447,14 @@ export default defineContentScript({
       activeModifiers.push(modifier)
       void reconcileFaceDetector()
       void reconcileBackground(modifier)
+
+      // Preserve audio tracks from the original stream — the modifier only
+      // produces video output.
+      for (const audioTrack of original.getAudioTracks()) {
+        modifier.outputStream.addTrack(audioTrack)
+        trackToModifier.set(audioTrack, modifier)
+      }
+
       return modifier.outputStream
     }
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
This pull request makes improvements to the `injector.content.ts` content script, focusing on better handling of media streams and a minor code formatting update. The most important changes are grouped below:

Media Stream Handling Improvements:

* When applying a video modifier, the code now ensures that all audio tracks from the original media stream are preserved and added to the modifier's output stream. This ensures that audio is not lost when video modifiers are applied.

Code Formatting:

* The conditional statement that checks for `chrome-extension://` URLs was reformatted onto a single line for consistency and readability, without changing its logic.